### PR TITLE
IS-1603: Add standard header for dialogmote documents

### DIFF
--- a/data/isdialogmote/avlysning-v2.json
+++ b/data/isdialogmote/avlysning-v2.json
@@ -1,0 +1,45 @@
+{
+  "mottakerNavn": "Artig Trane",
+  "mottakerFodselsnummer": "12345678945",
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": [
+        "Avlysning av dialogmøte"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Sendt 9. mars 2022, kl. 12.00"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Gjelder Artig Trane, f.nr. 12345678945"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "NAV har tidligere innkalt til dialogmøte som skulle vært avholdt 22.10.2021 klokka 12. Dette møtet er avlyst."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Her kommer en fritekst skrevet av veilederen."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Med hilsen",
+        "NAV Staden",
+        "Kari Saksbehandler"
+      ]
+    }
+  ]
+}

--- a/data/isdialogmote/endring-tid-sted-v2.json
+++ b/data/isdialogmote/endring-tid-sted-v2.json
@@ -1,0 +1,62 @@
+{
+  "mottakerNavn": "Artig Trane",
+  "mottakerFodselsnummer": "12345678945",
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": [
+        "Endret dialogmøte"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Sendt 9. mars 2022, kl. 12.00"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Møtetidspunkt",
+      "texts": [
+        "20. mai 2021, Storgata 4"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Møtested",
+      "texts": [
+        "Videomøte på Teams"
+      ]
+    },
+    {
+      "type": "LINK",
+      "title": "Lenke til videomøte",
+      "texts": [
+        "https://teams.microsoft.com/l/osv.osv.osv"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Gjelder Artig Trane, f.nr. 12345678945"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Tid og/eller sted for dialogmøtet har blitt endret."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Med hilsen",
+        "NAV Staden",
+        "Kari Saksbehandler",
+        "kari@nav.no",
+        "99998888"
+      ]
+    }
+  ]
+}

--- a/data/isdialogmote/innkalling-v2.json
+++ b/data/isdialogmote/innkalling-v2.json
@@ -1,0 +1,93 @@
+{
+  "mottakerNavn": "Artig Trane",
+  "mottakerFodselsnummer": "12345678945",
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": [
+        "Innkalling til dialogmøte"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Sendt 9. mars 2022, kl. 12.00"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Møtetidspunkt",
+      "texts": [
+        "20. mai 2021, Storgata 4"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Møtested",
+      "texts": [
+        "Videomøte på Teams"
+      ]
+    },
+    {
+      "type": "LINK",
+      "title": "Lenke til videomøte",
+      "texts": [
+        "https://teams.microsoft.com/l/osv.osv.osv"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Gjelder Artig Trane, f.nr. 12345678945"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Her kommer en fritekst skrevet av veilederen."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med NAV og sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til NAV senest 1 uke før møtet avholdes."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Hvis vårt forslag til møtetidspunkt, møtested eller møteform ikke passer, ber vi om at du tar kontakt for å diskutere alternativer.] I så fall kan du sende epost eller ringe undertegnede på telefon. Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Etter reglene kan NAV be sykmelder eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Før møtet",
+      "texts": [
+        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Det gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Med hilsen",
+        "NAV Staden",
+        "Kari Saksbehandler",
+        "kari@nav.no",
+        "99998888"
+      ]
+    }
+  ]
+}

--- a/data/isdialogmote/referat-v2.json
+++ b/data/isdialogmote/referat-v2.json
@@ -1,0 +1,130 @@
+{
+  "mottakerNavn": "Artig Trane",
+  "mottakerFodselsnummer": "12345678945",
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": [
+        "Referat fra dialogmøte"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Sendt 9. mars 2022, kl. 12.00"
+      ]
+    },
+    {
+      "type": "HEADER_H2",
+      "texts": [
+        "Artig Trane, 30. april 2021, på Frisk legekontor"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Deltakere i møtet",
+      "texts": [
+        "Arbeidstaker: Artig Trane",
+        "Arbeidsgiver: Grønn Bamse",
+        "Fra NAV: Kari Saksbehandler"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Formålet med møtet var å oppsummere situasjonen, drøfte mulighetene for å arbeide og legge en plan for tiden framover."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Sykdom og diagnose er underlagt taushetsplikt. Derfor er helsen din bare et tema hvis du selv velger å være åpen om den. Av hensyn til personvernet inneholder referatet uansett ikke slike opplysninger."
+      ]
+    },
+    {
+      "type": "HEADER_H2",
+      "texts": [
+        "Dette skjedde i møtet"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Konklusjon",
+      "texts": [
+        "Pulchritudine velums, tanquam superbus boreas. Ubi est castus classis. Impositio de domesticus visus, promissio nutrix."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Din oppgave",
+      "texts": [
+        "Cum humani generis ortum, omnes accolaes captis fatalis, bassus tumultumquees. Ortum semper ducunt ad nobilis calceus."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Arbeidsgiverens oppgave",
+      "texts": [
+        "Festus vita vix experientias nutrix est. Hercle, abactor dexter. "
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "NAVs oppgave",
+      "texts": [
+        "Cum epos favere, omnes medicinaes demitto nobilis, barbatus rectores. Est camerarius genetrix, cesaris."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "title": "Situasjon og muligheter",
+      "texts": [
+        "Cum assimilatio messis, omnes xiphiases imitari ferox, domesticus danistaes. Hercle, habena gratis. Nunquam acquirere abnoba."
+      ]
+    },
+    {
+      "type": "HEADER_H2",
+      "texts": [
+        "Dette informerte NAV om i møtet"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "key": "AVKLARING_ARBEIDSEVNE",
+      "title": "Avklaring om arbeidsevnen",
+      "texts": [
+        "Du kan få kartlagt eller prøvd ut arbeidsevnen din. Avklaringen kan skje der du jobber eller på en annen arbeidsplass. Da undersøker vi om du kan utføre jobben med noen tilpasninger, om du kan få påfyll av kompetanse, eller om det er muligheter i et annet yrke. Avklaringen varer som regel i fire uker, men kan forlenges inntil åtte uker ved behov."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "key": "FRISKMELDING_ARBEIDSFORMIDLING",
+      "title": "Friskmelding til arbeidsformidling",
+      "texts": [
+        "Denne ordningen er aktuell dersom helsen din er slik at du kan komme tilbake i arbeid, men ikke til den jobben du er sykmeldt fra. Hvis alle muligheter for å komme tilbake til arbeidsplassen din er forsøkt, kan du få sykepenger i inntil 12 uker mens du søker ny jobb. Maksimal periode med sykepenger er 52 uker, inkludert ukene med friskmelding til arbeidsformidling."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "key": "OKONOMISK_STOTTE",
+      "title": "Hjelp til å søke om annen økonomisk støtte",
+      "texts": [
+        "Klarer du ikke å komme tilbake i arbeid før den siste dagen du har rett til sykepenger, trenger vi et nytt dialogmøte. Da vil vi snakke sammen om hvordan du eventuelt kan søke om annen økonomisk støtte fra NAV."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Med hilsen",
+        "NAV Staden"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Kari Saksbehandler"
+      ]
+    }
+  ]
+}

--- a/templates/isdialogmote/avlysning-v2.hbs
+++ b/templates/isdialogmote/avlysning-v2.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> partials/head doctitle="Dialogmøte"}}
+<body>
+{{> partials/header }}
+
+{{> partials/content }}
+</body>
+</html>

--- a/templates/isdialogmote/endring-tid-sted-v2.hbs
+++ b/templates/isdialogmote/endring-tid-sted-v2.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> partials/head doctitle="Dialogmøte"}}
+<body>
+{{> partials/header }}
+
+{{> partials/content }}
+</body>
+</html>

--- a/templates/isdialogmote/innkalling-v2.hbs
+++ b/templates/isdialogmote/innkalling-v2.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> partials/head doctitle="Dialogmøte"}}
+<body>
+{{> partials/header }}
+
+{{> partials/content }}
+</body>
+</html>

--- a/templates/isdialogmote/referat-v2.hbs
+++ b/templates/isdialogmote/referat-v2.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> partials/head doctitle="Referat"}}
+<body>
+{{> partials/header }}
+
+{{> partials/content }}
+</body>
+</html>

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -1,7 +1,11 @@
 <div class="header">
     <div class="mottaker-info-container">
-        <p class="mottaker">Til: {{ mottakerNavn }}</p>
-        <p class="fodselsnummer">Fødselsnummer: {{ mottakerFodselsnummer }}</p>
+        {{#if mottakerNavn}}
+            <p class="mottaker">Til: {{ mottakerNavn }}</p>
+        {{/if}}
+        {{#if mottakerFodselsnummer}}
+            <p class="fodselsnummer">Fødselsnummer: {{ mottakerFodselsnummer }}</p>
+        {{/if}}
     </div>
     <div class="logo-container">
         <img class="navlogo" alt="Nav-logo" src="{{ image "Navlogo.png" }}"/>


### PR DESCRIPTION
La til ny versjon av dialogmøte dokumenter som inneholder header.
Nye url'er er:
- `api/v1/genpdf/isdialogmote/avlysning-v2`
- `api/v1/genpdf/isdialogmote/innkalling-v2`
- `api/v1/genpdf/isdialogmote/endring-tid-sted-v2`
- `api/v1/genpdf/isdialogmote/referat-v2`

PR i `isdialogmote` kommer.

![Screenshot 2024-04-30 at 09 44 51](https://github.com/navikt/ispdfgen/assets/11747383/9f51b90e-dd16-4973-bde9-844dc7a0fe5f)
![Screenshot 2024-04-30 at 09 45 40](https://github.com/navikt/ispdfgen/assets/11747383/58b531f1-55b1-4553-b399-1ecde6daab52)
![Screenshot 2024-04-30 at 09 46 17](https://github.com/navikt/ispdfgen/assets/11747383/ab28aa1f-669d-4ac2-ba75-ac39fc2ce768)
![Screenshot 2024-04-30 at 09 47 06](https://github.com/navikt/ispdfgen/assets/11747383/7f7a8b48-b0a5-4d24-8310-5e903eb0ff29)


