### PR TITLE
IS-2342: Add aktivitetskrav pdfs

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -36,6 +36,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: isaktivitetskrav
         - application: isfrisktilarbeid
         - application: isarbeidsuforhet
         - application: isdialogmote

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -36,6 +36,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: isaktivitetskrav
         - application: isfrisktilarbeid
         - application: isarbeidsuforhet
         - application: isdialogmote

--- a/data/isaktivitetskrav/aktivitetskrav-vurdering.json
+++ b/data/isaktivitetskrav/aktivitetskrav-vurdering.json
@@ -1,0 +1,41 @@
+{
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": [
+        "Vurdering av aktivitetskravet"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Gjelder Artig Trane, f.nr. 12345678945"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Det ble vurdert unntak fra aktivitetskravet den 14. desember 2023. Årsak: Medisinske grunner."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Vedtak ble fattet etter folketrygdloven § 8-8 andre ledd, samt tilhørende rundskriv."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Vurdert av Kari Saksbehandler"
+      ]
+    }
+  ]
+}

--- a/data/isaktivitetskrav/forhandsvarsel-til-innbygger-om-stans-av-sykepenger.json
+++ b/data/isaktivitetskrav/forhandsvarsel-til-innbygger-om-stans-av-sykepenger.json
@@ -1,0 +1,78 @@
+{
+  "mottakerNavn": "Artig Trane",
+  "mottakerFodselsnummer": "12345678945",
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": [
+        "Varsel om stans av sykepenger"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med [sett inn dato 3 uker frem i tid]."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
+    },
+    {
+      "type": "HEADER_H3",
+      "texts": [
+        "Du kan unngå stans av sykepenger"
+      ]
+    },
+    {
+      "type": "BULLET_POINTS",
+      "texts": [
+        "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden.",
+        "Gir arbeidsgiveren din en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, kan utbetalingen av sykepenger fortsette.",
+        "Går det fram av sykmeldingen at du er for syk til å arbeide, får du fortsatt sykepenger."
+      ]
+    },
+    {
+      "type": "HEADER_H3",
+      "texts": [
+        "Gi oss tilbakemelding"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Vi må ha tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen 10. oktober 2023 {dato 3 uker frem i tid}. Ellers vil sykepengene dine stanses fra denne datoen.",
+        "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33."
+      ]
+    },
+    {
+      "type": "HEADER_H3",
+      "texts": [
+        "Lovhjemmel"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Aktivitetsplikten er beskrevet i folketrygdloven § 8-8 2.ledd."
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "«Medlemmet har plikt til å være i arbeidsrelatert aktivitet, jf. § 8-7 a første ledd og arbeidsmiljøloven § 4-6 første ledd, så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet, eller arbeidsrelaterte aktiviteter ikke kan gjennomføres på arbeidsplassen.»"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "NAV"
+      ]
+    }
+  ]
+}

--- a/templates/isaktivitetskrav/aktivitetskrav-vurdering.hbs
+++ b/templates/isaktivitetskrav/aktivitetskrav-vurdering.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> partials/head doctitle="Vurdering av aktivitetskravet"}}
+<body>
+{{> partials/header }}
+
+{{> partials/content }}
+</body>
+</html>

--- a/templates/isaktivitetskrav/forhandsvarsel-til-innbygger-om-stans-av-sykepenger.hbs
+++ b/templates/isaktivitetskrav/forhandsvarsel-til-innbygger-om-stans-av-sykepenger.hbs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> partials/head doctitle="Varsel om stans av sykepenger"}}
+<body>
+{{> partials/header }}
+
+{{> partials/content }}
+</body>
+</html>


### PR DESCRIPTION
Legger til aktivitetskrav pdf'er
- Dokument for forhåndsvarsel om stans
- Dokument for vurdering som journalføres (Har fått lagt på en header som den ikke hadde i `isaktivitetskravpdfgen`

Se [tilhørende PR](https://github.com/navikt/isaktivitetskrav/pull/215) i `isaktivitetskrav`

<img width="793" alt="Screenshot 2024-05-10 at 11 34 50" src="https://github.com/navikt/ispdfgen/assets/11747383/d1822a88-7c16-4b2b-8805-9df6f3d5550f">
<img width="798" alt="Screenshot 2024-05-10 at 11 33 55" src="https://github.com/navikt/ispdfgen/assets/11747383/568b53c6-5d2a-4ddf-8f9c-f2ada7c7558f">
