### PR TITLE
IS-1801: Add innstilling om stans document for aktivitetskrav

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ It is a known issue that pdfgen's output documents look different depending on w
 has `\r\n` or `\n` as line endings. Therefore, it is strongly recommended to configure Git to not convert newlines, as well as ensure that your editor ends its lines with LF (`\n`) and not CRLF (`\r\n`), as the former will accurately show what your
 templates will look like in production.
 
-### For NAV employees
+### For Nav employees
 We are available at the Slack channel #isyfo

--- a/data/isaktivitetskrav/forhandsvarsel-til-innbygger-om-stans-av-sykepenger.json
+++ b/data/isaktivitetskrav/forhandsvarsel-til-innbygger-om-stans-av-sykepenger.json
@@ -12,7 +12,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med [sett inn dato 3 uker frem i tid]."
+        "Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene Nav har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med [sett inn dato 3 uker frem i tid]."
       ]
     },
     {
@@ -71,7 +71,7 @@
       "texts": [
         "Med vennlig hilsen",
         "Kari Saksbehandler",
-        "NAV"
+        "Nav"
       ]
     }
   ]

--- a/data/isaktivitetskrav/innstilling-om-stans-av-sykepenger.json
+++ b/data/isaktivitetskrav/innstilling-om-stans-av-sykepenger.json
@@ -1,43 +1,39 @@
 {
-  "mottakerNavn": "Artig Trane",
-  "mottakerFodselsnummer": "12345678945",
   "datoSendt": "19. september 2023",
   "documentComponents": [
     {
       "type": "HEADER_H1",
       "texts": [
-        "Avlysning av dialogmøte"
+        "Nav har stanset sykepengene dine"
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Sendt 9. mars 2022, kl. 12.00"
+        "Nav har stanset sykepengene dine fra og med 19. september 2023."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Gjelder Artig Trane, f.nr. 12345678945"
+        "For å få sykepenger har du plikt til å være i arbeidsrettet aktivitet innen 8 uker."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Nav har tidligere innkalt til dialogmøte som skulle vært avholdt 22.10.2021 klokka 12. Dette møtet er avlyst."
+        "Her kommer friteksten som veileder skriver inn."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Her kommer en fritekst skrevet av veilederen."
+        "Vi har brukt folketrygdloven § 8-8 andre ledd når vi har behandlet saken din."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Med hilsen",
-        "Nav Staden",
         "Kari Saksbehandler"
       ]
     }

--- a/data/isarbeidsuforhet/forhandsvarsel-om-avslag-pa-sykepenger.json
+++ b/data/isarbeidsuforhet/forhandsvarsel-om-avslag-pa-sykepenger.json
@@ -5,15 +5,23 @@
   "documentComponents": [
     {
       "type": "HEADER_H1",
-      "texts": ["Varsel om avslag på sykepenger"]
+      "texts": [
+        "Varsel om avslag på sykepenger"
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Her kommer friteksten som veileder skriver inn."]
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "Nav"
+      ]
     }
   ]
 }

--- a/data/isarbeidsuforhet/vurdering-av-arbeidsuforhet.json
+++ b/data/isarbeidsuforhet/vurdering-av-arbeidsuforhet.json
@@ -5,15 +5,23 @@
   "documentComponents": [
     {
       "type": "HEADER_H1",
-      "texts": ["Vurdering av arbeidsuførhet"]
+      "texts": [
+        "Vurdering av arbeidsuførhet"
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Her kommer friteksten som veileder skriver inn."]
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "Nav"
+      ]
     }
   ]
 }

--- a/data/isbehandlerdialog/foresporselompasient-legeerklaring.json
+++ b/data/isbehandlerdialog/foresporselompasient-legeerklaring.json
@@ -17,26 +17,26 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Som et ledd i NAVs videre oppfølging av pasienten din har vi behov for informasjon fra deg."
+        "Som et ledd i Navs videre oppfølging av pasienten din har vi behov for informasjon fra deg."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Opplysninger som etter din vurdering faller utenfor formålet, kan du utelate i oversendelsen til NAV."
+        "Opplysninger som etter din vurdering faller utenfor formålet, kan du utelate i oversendelsen til Nav."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
-        "«Legeerklæring ved arbeidsuførhet» leveres på blankett NAV 08-07.08, og honoreres med takst L40."
+        "«Legeerklæring ved arbeidsuførhet» leveres på blankett Nav 08-07.08, og honoreres med takst L40."
       ]
     },
     {
       "type": "PARAGRAPH",
       "title": "Lovhjemmel",
       "texts": [
-        "Folketrygdloven § 21-4 andre ledd gir NAV rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd."
+        "Folketrygdloven § 21-4 andre ledd gir Nav rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd."
       ]
     },
     {
@@ -49,7 +49,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Siri Saksbehandler"
       ]
     }

--- a/data/isbehandlerdialog/foresporselompasient-paminnelse.json
+++ b/data/isbehandlerdialog/foresporselompasient-paminnelse.json
@@ -36,7 +36,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Siri Saksbehandler"
       ]
     }

--- a/data/isbehandlerdialog/foresporselompasient-tilleggsopplysninger.json
+++ b/data/isbehandlerdialog/foresporselompasient-tilleggsopplysninger.json
@@ -17,7 +17,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "NAV trenger opplysninger fra deg vedrørende din pasient. Du kan utelate opplysninger som etter din vurdering faller utenfor formålet."
+        "Nav trenger opplysninger fra deg vedrørende din pasient. Du kan utelate opplysninger som etter din vurdering faller utenfor formålet."
       ]
     },
     {
@@ -36,7 +36,7 @@
       "type": "PARAGRAPH",
       "title": "Lovhjemmel",
       "texts": [
-        "Folketrygdloven § 21-4 andre ledd gir NAV rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd."
+        "Folketrygdloven § 21-4 andre ledd gir Nav rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd."
       ]
     },
     {
@@ -50,7 +50,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Siri Saksbehandler"
       ]
     }

--- a/data/isbehandlerdialog/henvendelse-meldingfranav.json
+++ b/data/isbehandlerdialog/henvendelse-meldingfranav.json
@@ -5,7 +5,7 @@
     {
       "type": "HEADER_H1",
       "texts": [
-        "Melding fra NAV"
+        "Melding fra Nav"
       ]
     },
     {
@@ -18,7 +18,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Siri Saksbehandler"
       ]
     }

--- a/data/isbehandlerdialog/henvendelse-retur-legeerklaring.json
+++ b/data/isbehandlerdialog/henvendelse-retur-legeerklaring.json
@@ -17,7 +17,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Vi har mottatt Legeerklæring ved arbeidsuførhet (NAV 08-07.08). Vi ber om at du sender oss en ny legeerklæring snarest mulig."
+        "Vi har mottatt Legeerklæring ved arbeidsuførhet (Nav 08-07.08). Vi ber om at du sender oss en ny legeerklæring snarest mulig."
       ]
     },
     {
@@ -42,7 +42,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Siri Saksbehandler"
       ]
     }

--- a/data/isdialogmote/avlysning.json
+++ b/data/isdialogmote/avlysning.json
@@ -21,7 +21,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "NAV har tidligere innkalt til dialogmøte som skulle vært avholdt 22.10.2021 klokka 12. Dette møtet er avlyst."
+        "Nav har tidligere innkalt til dialogmøte som skulle vært avholdt 22.10.2021 klokka 12. Dette møtet er avlyst."
       ]
     },
     {
@@ -34,7 +34,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Kari Saksbehandler"
       ]
     }

--- a/data/isdialogmote/endring-tid-sted-v2.json
+++ b/data/isdialogmote/endring-tid-sted-v2.json
@@ -52,7 +52,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Kari Saksbehandler",
         "kari@nav.no",
         "99998888"

--- a/data/isdialogmote/endring-tidsted.json
+++ b/data/isdialogmote/endring-tidsted.json
@@ -49,7 +49,7 @@
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Kari Saksbehandler",
         "kari@nav.no",
         "99998888"

--- a/data/isdialogmote/innkalling-v2.json
+++ b/data/isdialogmote/innkalling-v2.json
@@ -45,7 +45,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre."
+        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra Nav. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre."
       ]
     },
     {
@@ -57,7 +57,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med NAV og sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til NAV senest 1 uke før møtet avholdes."
+        "Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med Nav og sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til Nav senest 1 uke før møtet avholdes."
       ]
     },
     {
@@ -69,21 +69,21 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Etter reglene kan NAV be sykmelder eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det."
+        "Etter reglene kan Nav be sykmelder eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det."
       ]
     },
     {
       "type": "PARAGRAPH",
       "title": "Før møtet",
       "texts": [
-        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Det gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover."
+        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med Nav. Det gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Kari Saksbehandler",
         "kari@nav.no",
         "99998888"

--- a/data/isdialogmote/innkalling.json
+++ b/data/isdialogmote/innkalling.json
@@ -42,7 +42,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre."
+        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra Nav. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre."
       ]
     },
     {
@@ -54,7 +54,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med NAV og sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til NAV senest 1 uke før møtet avholdes."
+        "Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med Nav og sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til Nav senest 1 uke før møtet avholdes."
       ]
     },
     {
@@ -66,21 +66,21 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Etter reglene kan NAV be sykmelder eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det."
+        "Etter reglene kan Nav be sykmelder eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det."
       ]
     },
     {
       "type": "PARAGRAPH",
       "title": "Før møtet",
       "texts": [
-        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Det gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover."
+        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med Nav. Det gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden",
+        "Nav Staden",
         "Kari Saksbehandler",
         "kari@nav.no",
         "99998888"

--- a/data/isdialogmote/referat-v2.json
+++ b/data/isdialogmote/referat-v2.json
@@ -27,7 +27,7 @@
       "texts": [
         "Arbeidstaker: Artig Trane",
         "Arbeidsgiver: Grønn Bamse",
-        "Fra NAV: Kari Saksbehandler"
+        "Fra Nav: Kari Saksbehandler"
       ]
     },
     {
@@ -71,7 +71,7 @@
     },
     {
       "type": "PARAGRAPH",
-      "title": "NAVs oppgave",
+      "title": "Navs oppgave",
       "texts": [
         "Cum epos favere, omnes medicinaes demitto nobilis, barbatus rectores. Est camerarius genetrix, cesaris."
       ]
@@ -86,7 +86,7 @@
     {
       "type": "HEADER_H2",
       "texts": [
-        "Dette informerte NAV om i møtet"
+        "Dette informerte Nav om i møtet"
       ]
     },
     {
@@ -110,14 +110,14 @@
       "key": "OKONOMISK_STOTTE",
       "title": "Hjelp til å søke om annen økonomisk støtte",
       "texts": [
-        "Klarer du ikke å komme tilbake i arbeid før den siste dagen du har rett til sykepenger, trenger vi et nytt dialogmøte. Da vil vi snakke sammen om hvordan du eventuelt kan søke om annen økonomisk støtte fra NAV."
+        "Klarer du ikke å komme tilbake i arbeid før den siste dagen du har rett til sykepenger, trenger vi et nytt dialogmøte. Da vil vi snakke sammen om hvordan du eventuelt kan søke om annen økonomisk støtte fra Nav."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden"
+        "Nav Staden"
       ]
     },
     {

--- a/data/isdialogmote/referat.json
+++ b/data/isdialogmote/referat.json
@@ -24,7 +24,7 @@
       "texts": [
         "Arbeidstaker: Artig Trane",
         "Arbeidsgiver: Grønn Bamse",
-        "Fra NAV: Kari Saksbehandler"
+        "Fra Nav: Kari Saksbehandler"
       ]
     },
     {
@@ -68,7 +68,7 @@
     },
     {
       "type": "PARAGRAPH",
-      "title": "NAVs oppgave",
+      "title": "Navs oppgave",
       "texts": [
         "Cum epos favere, omnes medicinaes demitto nobilis, barbatus rectores. Est camerarius genetrix, cesaris."
       ]
@@ -83,7 +83,7 @@
     {
       "type": "HEADER_H2",
       "texts": [
-        "Dette informerte NAV om i møtet"
+        "Dette informerte Nav om i møtet"
       ]
     },
     {
@@ -107,14 +107,14 @@
       "key": "OKONOMISK_STOTTE",
       "title": "Hjelp til å søke om annen økonomisk støtte",
       "texts": [
-        "Klarer du ikke å komme tilbake i arbeid før den siste dagen du har rett til sykepenger, trenger vi et nytt dialogmøte. Da vil vi snakke sammen om hvordan du eventuelt kan søke om annen økonomisk støtte fra NAV."
+        "Klarer du ikke å komme tilbake i arbeid før den siste dagen du har rett til sykepenger, trenger vi et nytt dialogmøte. Da vil vi snakke sammen om hvordan du eventuelt kan søke om annen økonomisk støtte fra Nav."
       ]
     },
     {
       "type": "PARAGRAPH",
       "texts": [
         "Med hilsen",
-        "NAV Staden"
+        "Nav Staden"
       ]
     },
     {

--- a/data/isfrisktilarbeid/vedtak-om-friskmelding-til-arbeidsformidling.json
+++ b/data/isfrisktilarbeid/vedtak-om-friskmelding-til-arbeidsformidling.json
@@ -5,15 +5,23 @@
   "documentComponents": [
     {
       "type": "HEADER_H1",
-      "texts": ["Vedtak om friskmelding til arbeidsformidling"]
+      "texts": [
+        "Vedtak om friskmelding til arbeidsformidling"
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Her kommer friteksten som veileder skriver inn."]
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "Nav"
+      ]
     }
   ]
 }

--- a/data/ismanglendemedvirkning/forhandsvarsel-om-stans-av-sykepenger.json
+++ b/data/ismanglendemedvirkning/forhandsvarsel-om-stans-av-sykepenger.json
@@ -5,15 +5,23 @@
   "documentComponents": [
     {
       "type": "HEADER_H1",
-      "texts": ["Varsel om stans av sykepenger"]
+      "texts": [
+        "Varsel om stans av sykepenger"
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Her kommer friteksten som veileder skriver inn."]
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "Nav"
+      ]
     }
   ]
 }

--- a/data/ismanglendemedvirkning/innstilling-om-stans.json
+++ b/data/ismanglendemedvirkning/innstilling-om-stans.json
@@ -3,15 +3,23 @@
   "documentComponents": [
     {
       "type": "HEADER_H1",
-      "texts": ["Innstilling om stans av sykepenger"]
+      "texts": [
+        "Innstilling om stans av sykepenger"
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Her kommer friteksten som veileder skriver inn."]
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "Nav"
+      ]
     }
   ]
 }

--- a/data/ismanglendemedvirkning/vurdering-av-manglende-medvirkning.json
+++ b/data/ismanglendemedvirkning/vurdering-av-manglende-medvirkning.json
@@ -3,15 +3,23 @@
   "documentComponents": [
     {
       "type": "HEADER_H1",
-      "texts": ["Vurdering av manglende medvirkning"]
+      "texts": [
+        "Vurdering av manglende medvirkning"
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Her kommer friteksten som veileder skriver inn."]
+      "texts": [
+        "Her kommer friteksten som veileder skriver inn."
+      ]
     },
     {
       "type": "PARAGRAPH",
-      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+      "texts": [
+        "Med vennlig hilsen",
+        "Kari Saksbehandler",
+        "Nav"
+      ]
     }
   ]
 }

--- a/data/padm2/padm2.json
+++ b/data/padm2/padm2.json
@@ -18,7 +18,7 @@
           "s": "2.16.578.1.12.4.1.1.8125",
           "v": "1"
         },
-        "sporsmal": "Endret møtetidspunkt for dialogmøteGjelder Test Etternavn.NAV har tidligere innkalt til et dialogmøte angående din pasient. Møtet skulle vært\n                                    avholdt 03.09.2020 klokken 14:00.Dette møtet må flyttes, og vi foreslår nytt møtetidspunkt 22.09.2020 klokken 12:00.Møtested: SvingenHvis tidspunktet ikke\n                                    passer ber vi om en rask tilbakemelding.Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med NAV med mindre det er gyldig grunn for\n                                    fravær.Fastlege deltar pr telefon. Med hilsenNAVJon PersonAktuelle lover: Både folketrygdloven og arbeidsmiljøloven har bestemmelser om\n                                    sykefraværsoppfølging:Folketrygdloven § 8-4 og § 8-7Arbeidsmiljøloven § 4-6InformasjonØnsker du mer informasjon om regler og ordninger for oppfølging av\n                                    sykmeldte?www.nav.no og www.arbeidstilsynet.no Lokalt NAV-kontor",
+        "sporsmal": "Endret møtetidspunkt for dialogmøteGjelder Test Etternavn.Nav har tidligere innkalt til et dialogmøte angående din pasient. Møtet skulle vært\n                                    avholdt 03.09.2020 klokken 14:00.Dette møtet må flyttes, og vi foreslår nytt møtetidspunkt 22.09.2020 klokken 12:00.Møtested: SvingenHvis tidspunktet ikke\n                                    passer ber vi om en rask tilbakemelding.Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med Nav med mindre det er gyldig grunn for\n                                    fravær.Fastlege deltar pr telefon. Med hilsenNAVJon PersonAktuelle lover: Både folketrygdloven og arbeidsmiljøloven har bestemmelser om\n                                    sykefraværsoppfølging:Folketrygdloven § 8-4 og § 8-7Arbeidsmiljøloven § 4-6InformasjonØnsker du mer informasjon om regler og ordninger for oppfølging av\n                                    sykmeldte?www.nav.no og www.arbeidstilsynet.no Lokalt Nav-kontor",
         "dokIdForesp": "OD1812186729156",
         "rollerRelatertNotat": {
           "rolleNotat": {
@@ -105,5 +105,5 @@
   "pasientFnr": "3214141414",
   "pasientNavn": "Koronasen, Kovid",
   "navnSignerendeLege": "Sjefslege, Bossie",
-  "antallVedlegg" : 1
+  "antallVedlegg": 1
 }

--- a/templates/isaktivitetskrav/innstilling-om-stans-av-sykepenger.hbs
+++ b/templates/isaktivitetskrav/innstilling-om-stans-av-sykepenger.hbs
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
-{{> partials/head doctitle="Melding fra Nav"}}
+{{> partials/head doctitle="Innstilling om stans"}}
 <body>
-{{> partials/header-red-logo }}
-
 {{> partials/content }}
 </body>
 </html>

--- a/templates/padm2/partials/base.hbs
+++ b/templates/padm2/partials/base.hbs
@@ -22,7 +22,7 @@
         }
 
         h3 {
-            margin: 1.5em 0 0.5em  0;
+            margin: 1.5em 0 0.5em 0;
         }
 
         td {
@@ -66,7 +66,7 @@
         <th>Til</th>
     </tr>
     <tr>
-        <td class="cellBottom">NAV</td>
+        <td class="cellBottom">Nav</td>
     </tr>
 
     <tr>


### PR DESCRIPTION
- Legger til muligheten for å hente pdf av innstilling om stans for aktivitetskravet på `/api/v1/genpdf/isaktivitetskrav/innstilling-om-stans-av-sykepenger`.
- Endret fra NAV til Nav på eksempelfilene

Se [tilhørende PR](https://github.com/navikt/isaktivitetskrav/pull/283) i `isaktivitetskrav`

Se screenshot for eksempel 👇 

<img width="796" alt="Screenshot 2025-02-10 at 16 36 15" src="https://github.com/user-attachments/assets/7096b790-e0f3-4730-8e68-4bd7ae8c6804" />
