### PR TITLE
IS-1801-2: Add header to aktivitetskrav innstilling om stans

### DIFF
--- a/data/isaktivitetskrav/innstilling-om-stans-av-sykepenger.json
+++ b/data/isaktivitetskrav/innstilling-om-stans-av-sykepenger.json
@@ -4,7 +4,13 @@
     {
       "type": "HEADER_H1",
       "texts": [
-        "Nav har stanset sykepengene dine"
+        "Vurdering av aktivitetskravet - Innstilling om stans"
+      ]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": [
+        "Gjelder Artig Trane, f.nr. 12345678945"
       ]
     },
     {
@@ -34,7 +40,7 @@
     {
       "type": "PARAGRAPH",
       "texts": [
-        "Kari Saksbehandler"
+        "Vurdert av Kari Saksbehandler"
       ]
     }
   ]

--- a/templates/isaktivitetskrav/innstilling-om-stans-av-sykepenger.hbs
+++ b/templates/isaktivitetskrav/innstilling-om-stans-av-sykepenger.hbs
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="no">
-{{> partials/head doctitle="Innstilling om stans"}}
+{{> partials/head doctitle="Vurdering av aktivitetskravet - Innstilling om stans"}}
 <body>
+{{> partials/header }}
+
 {{> partials/content }}
 </body>
 </html>


### PR DESCRIPTION
Legger til header til pdf'en som genereres på 
`/isaktivitetskrav/innstilling-om-stans-av-sykepenger`

Nav logo i header er lagt på👇
![Screenshot 2025-02-20 at 12 10 25](https://github.com/user-attachments/assets/46ecef83-46ec-4fd3-a35d-b256aaf9583d)
