### PR TITLE
IS-2809: Fix warning about pdf/ua

### DIFF
--- a/templates/padm2/partials/base.hbs
+++ b/templates/padm2/partials/base.hbs
@@ -55,7 +55,7 @@
         }
 
     </style>
-    <title>{{ doctitle }} </title>
+    <title>{{> title }} </title>
 </head>
 <body>
 
@@ -106,7 +106,6 @@
 {{> padm2/partials/foresporselsvar }}
 {{> padm2/partials/henvendelsefralege }}
 {{> padm2/partials/avvist }}
-
 
 </body>
 </html>


### PR DESCRIPTION
Viser seg at `padm2` har en dokumentmal som ikke bruker samme "head" som de andre.