### PR TITLE
IS-3968: Disable pdfa-validation in production

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -60,4 +60,4 @@ spec:
     - name: ENABLE_PDF_GET
       value: "false"
     - name: ENABLE_PDFA_VALIDATION
-      value: "true"
+      value: "false"


### PR DESCRIPTION
Foreslår at vi skrur av pdfa-validering i produksjon: det har aldri slått til i praksis, og det mer enn fordobler tiden det tar å lage en pdf. 

Vi kan beholde det i dev-gcp slik at man oppdager evnt problemer under testing.